### PR TITLE
Object3D tween accepts generic

### DIFF
--- a/src/patch/Object3D.ts
+++ b/src/patch/Object3D.ts
@@ -137,9 +137,10 @@ export interface Object3DExtPrototype {
     unbindProperty<T extends keyof this>(property: T): this;
     /**
      * Initiates a Tween animation for the object.
+     * @template T - The type of the target.
      * @returns A Tween instance for further configuration.
      */
-    tween(): Tween<Object3D>;
+    tween<T extends Object3D>(): Tween<T>;
 }
 
 Object3D.prototype.focusable = true;
@@ -274,8 +275,8 @@ Object3D.prototype.unbindProperty = function (property) {
     return this;
 };
 
-Object3D.prototype.tween = function () {
-    return new Tween(this);
+Object3D.prototype.tween = function <T extends Object3D>() {
+    return new Tween<T>(this as T);
 };
 
 /** @internal */

--- a/src/types/Camera.d.ts
+++ b/src/types/Camera.d.ts
@@ -31,7 +31,7 @@ export class Camera extends CameraBase implements Object3DExtPrototype {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Camera>;
+    tween<T extends Object3D = Camera>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/CubeCamera.d.ts
+++ b/src/types/CubeCamera.d.ts
@@ -31,7 +31,7 @@ export class CubeCamera extends CubeCameraBase implements Object3DExtPrototype {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<CubeCamera>;
+    tween<T extends Object3D = CubeCamera>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/Group.d.ts
+++ b/src/types/Group.d.ts
@@ -31,7 +31,7 @@ export class Group extends GroupBase implements Object3DExtPrototype {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Group>;
+    tween<T extends Object3D = Group>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/InstancedMesh.d.ts
+++ b/src/types/InstancedMesh.d.ts
@@ -34,7 +34,7 @@ export class InstancedMesh<
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<InstancedMesh>;
+    tween<T extends Object3D = InstancedMesh>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/LOD.d.ts
+++ b/src/types/LOD.d.ts
@@ -31,7 +31,7 @@ export class LOD extends LODBase implements Object3DExtPrototype {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<LOD>;
+    tween<T extends Object3D = LOD>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/Line.d.ts
+++ b/src/types/Line.d.ts
@@ -34,7 +34,7 @@ export class Line<
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Line>;
+    tween<T extends Object3D = Line>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/Line2.d.ts
+++ b/src/types/Line2.d.ts
@@ -32,7 +32,7 @@ export class Line2 extends Line2Base implements Object3DExtPrototype {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Line2>;
+    tween<T extends Object3D = Line2>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/Mesh.d.ts
+++ b/src/types/Mesh.d.ts
@@ -34,7 +34,7 @@ export class Mesh<
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Mesh>;
+    tween<T extends Object3D = Mesh>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/Object3D.d.ts
+++ b/src/types/Object3D.d.ts
@@ -31,7 +31,7 @@ export class Object3D extends Object3DBase implements Object3DExtPrototype {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Object3D>;
+    tween<T extends Object3D>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/OrthographicCamera.d.ts
+++ b/src/types/OrthographicCamera.d.ts
@@ -31,7 +31,7 @@ export class OrthographicCamera extends OrthographicCameraBase implements Object
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<OrthographicCamera>;
+    tween<T extends Object3D = OrthographicCamera>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/PerspectiveCamera.d.ts
+++ b/src/types/PerspectiveCamera.d.ts
@@ -31,7 +31,7 @@ export class PerspectiveCamera extends PerspectiveCameraBase implements Object3D
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<PerspectiveCamera>;
+    tween<T extends Object3D = PerspectiveCamera>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/Points.d.ts
+++ b/src/types/Points.d.ts
@@ -31,7 +31,7 @@ export class Points extends PointsBase implements Object3DExtPrototype {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Points>;
+    tween<T extends Object3D = Points>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/Scene.d.ts
+++ b/src/types/Scene.d.ts
@@ -41,7 +41,7 @@ export class Scene extends SceneBase implements Object3DExtPrototype, SceneExtPr
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Scene>;
+    tween<T extends Object3D = Scene>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/SkinnedMesh.d.ts
+++ b/src/types/SkinnedMesh.d.ts
@@ -34,7 +34,7 @@ export class SkinnedMesh<
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<SkinnedMesh>;
+    tween<T extends Object3D = SkinnedMesh>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/src/types/Sprite.d.ts
+++ b/src/types/Sprite.d.ts
@@ -31,7 +31,7 @@ export class Sprite extends SpriteBase implements Object3DExtPrototype {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Sprite>;
+    tween<T extends Object3D = Sprite>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/Camera.d.ts
+++ b/typesDev/Camera.d.ts
@@ -43,7 +43,7 @@ export class Camera extends CameraBase implements Object3DExtPrototypeInternal {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Camera>;
+    tween<T extends Object3D = Camera>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/Group.d.ts
+++ b/typesDev/Group.d.ts
@@ -43,7 +43,7 @@ export class Group extends GroupBase implements Object3DExtPrototypeInternal {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Mesh>;
+    tween<T extends Object3D = Group>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/InstancedMesh.d.ts
+++ b/typesDev/InstancedMesh.d.ts
@@ -46,7 +46,7 @@ export class InstancedMesh<
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<InstancedMesh>;
+    tween<T extends Object3D = InstancedMesh>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/LOD.d.ts
+++ b/typesDev/LOD.d.ts
@@ -38,12 +38,12 @@ export class LOD extends LODBase implements Object3DExtPrototypeInternal {
     hasEvent<K extends keyof Events>(type: K, listener: (args: Events[K]) => void): boolean;
     off<K extends keyof Events>(type: K, listener: (args: Events[K]) => void): void;
     trigger<K extends keyof Events>(type: K, args: Events[K]): void;
-    triggerAncestor<K extends keyof Events>(type: K, args: Events[K]): void;
+    triggerAncestor<K extends keyof InteractionEvents>(type: K, args?: InteractionEvents[K]): void;
     setManualDetectionMode(): void;
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<LOD>;
+    tween<T extends Object3D = LOD>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/Line2.d.ts
+++ b/typesDev/Line2.d.ts
@@ -44,7 +44,7 @@ export class Line2 extends Line2Base implements Object3DExtPrototypeInternal {
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Line2>;
+    tween<T extends Object3D = Line2>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/Mesh.d.ts
+++ b/typesDev/Mesh.d.ts
@@ -46,7 +46,7 @@ export class Mesh<
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Mesh>;
+    tween<T extends Object3D = Mesh>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/Object3D.d.ts
+++ b/typesDev/Object3D.d.ts
@@ -43,7 +43,7 @@ export class Object3D extends Object3DBase implements Object3DExtPrototypeIntern
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Object3D>;
+    tween<T extends Object3D>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/OrthographicCamera.d.ts
+++ b/typesDev/OrthographicCamera.d.ts
@@ -43,7 +43,7 @@ export class OrthographicCamera extends OrthographicCameraBase implements Object
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<OrthographicCamera>;
+    tween<T extends Object3D = OrthographicCamera>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/PerspectiveCamera.d.ts
+++ b/typesDev/PerspectiveCamera.d.ts
@@ -43,7 +43,7 @@ export class PerspectiveCamera extends PerspectiveCameraBase implements Object3D
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<PerspectiveCamera>;
+    tween<T extends Object3D = PerspectiveCamera>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;

--- a/typesDev/Scene.d.ts
+++ b/typesDev/Scene.d.ts
@@ -55,7 +55,7 @@ export class Scene extends SceneBase implements Object3DExtPrototypeInternal, Sc
     detectChanges(recursive?: boolean): void;
     bindProperty<T extends keyof this>(property: T, getCallback: () => this[T], renderOnChange?: boolean): this;
     unbindProperty<T extends keyof this>(property: T): this;
-    tween(): Tween<Scene>;
+    tween<T extends Object3D = Scene>(): Tween<T>;
     override parent: Object3D;
     override children: Object3D[];
     override add(...object: (Object3DBase | Object3D)[]): this;


### PR DESCRIPTION
Now is possible to specity a generic.

```js
this.tween<Mesh>()
```

