### PR TITLE
Fix easings function context

### DIFF
--- a/src/tweening/Actions.ts
+++ b/src/tweening/Actions.ts
@@ -136,7 +136,7 @@ export class ActionMotion<T> implements IAction<T> {
 
     private getEasing(): EasingFunction {
         const easing = this.config?.easing ?? DEFAULT_EASING;
-        return typeof easing === "string" ? (easings[easing] ?? easings.linear) : easing;
+        return typeof easing === "string" ? (easings[easing].bind(easings) ?? easings.linear) : easing;
     }
 
     private vector3(key: string, actionValue: Vector3 | number, targetValue: Vector3): RunningAction<Vector3> {


### PR DESCRIPTION
Fixed the exception generated in easing functions that used the 'this' reference, like this:

```typescript
public easeInBounce(x: number): number {
    return 1 - this.easeOutBounce(1 - x);
}
```