### PR TITLE
Added DragTarget property to Object3D

### DIFF
--- a/src/events/DragAndDropManager.ts
+++ b/src/events/DragAndDropManager.ts
@@ -66,7 +66,7 @@ export class DragAndDropManager {
                     this._startIntersection = intersection;
                 }
             } else if (target.enabledState) {
-                this._target = target;
+                this._target = target.dragTarget ?? target;
                 this._startIntersection = intersection;
             }
         }

--- a/src/patch/Object3D.ts
+++ b/src/patch/Object3D.ts
@@ -43,6 +43,8 @@ export interface Object3DExtPrototype {
     interceptByRaycaster: boolean;
     /** Array of hitboxes for collision detection. */
     hitboxes: Mesh[];
+    /** Indicates which object will be dragged instead of this one. */
+    dragTarget: Object3D;
     /** Indicates whether the object can receive focus (default: true). */
     focusable: boolean;
     /** Indicates whether the object is draggable (default: false). */


### PR DESCRIPTION
Added the `dragTarget` property to the `Object3D`, useful for dragging an object different from the clicked one.