### PR TITLE
Added tween method to material

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { MaterialExtPrototype } from './patch/Material';
 import { Object3DExtPrototype } from './patch/Object3D';
 import { SceneExtPrototype } from './patch/Scene';
 
@@ -17,6 +18,7 @@ export * from './instancedMesh/EventsDispatcherInstanced';
 export * from './instancedMesh/InstancedMesh2';
 export * from './instancedMesh/InstancedMeshEntity';
 export * from './patch/Euler';
+export * from './patch/Material'
 export * from './patch/Matrix4';
 export * from './patch/Object3D';
 export * from './patch/Quaternion';
@@ -36,6 +38,10 @@ export * from './utils/Utils';
 
 declare module 'three/src/core/Object3D' {
     export interface Object3D extends Object3DExtPrototype { }
+}
+
+declare module 'three/src/Materials/Material' {
+    export interface Material extends MaterialExtPrototype { }
 }
 
 declare module 'three/src/scenes/Scene' {

--- a/src/patch/Material.ts
+++ b/src/patch/Material.ts
@@ -1,0 +1,19 @@
+import { Material } from "three";
+import { Tween } from "../tweening/Tween";
+
+/**
+ * Represents the prototype for extended Material functionality.
+ */
+export interface MaterialExtPrototype {
+    /**
+     * Initiates a Tween animation for the material.
+     * @param id - Unique identifier. If you start a new tween, the old one with the same id (if specified) will be stopped.
+     * @template T - The type of the target.
+     * @returns A Tween instance for further configuration.
+     */
+    tween<T extends this>(id?: string): Tween<T>;
+}
+
+Material.prototype.tween = function <T extends Material>(id?: string) {
+    return new Tween<T>(this as T).setId(id);
+};


### PR DESCRIPTION
I've added a tween method to the Material class similar to what has been done with Object3D.

This is an example:
```Typescript
const box = new Mesh(new BoxGeometry(0.1, 0.1, 0.1), new MeshBasicMaterial());
box.on(['pointerover', 'pointerout'], function (e) {
    this.material.tween('id').to(3000, { color: e.type === 'pointerover' ? 'red' : 'blue' }, { easing: 'easeOutElastic' }).start();
});
```