### PR TITLE
Tween: Fix elapsedTime to return NaN when browser page is inactive

### DIFF
--- a/src/tweening/RunningTween.ts
+++ b/src/tweening/RunningTween.ts
@@ -275,7 +275,8 @@ export class RunningTween<T = any> {
     private executeActions(block: RunningBlock): void {
         if (block.actions) {
             for (const action of block.actions) {
-                const alpha = block.reversed ? 1 - Math.min(1, block.elapsedTime / action.time) : Math.min(1, block.elapsedTime / action.time);
+				const elapsedTime = Math.min(1, block.elapsedTime / (action.time + 10 ** -12));
+                const alpha = block.reversed ? 1 - elapsedTime : elapsedTime;
                 const easedAlpha = action.easing?.call(this, alpha) ?? alpha;
                 const applyValue = block.config?.onProgress?.call(this.target, this.target, action.key, action.start, action.end, easedAlpha);
                 if (applyValue !== false) {


### PR DESCRIPTION
This pull request addresses an issue in the tween module where elapsedTime was returning NaN when the browser page was inactive.