### PR TITLE
Object3D: renamed isDragging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@three.ez/main",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Simplify three.js development, including events, drag & drop, binding, focus management, smart rendering, tweening and more.",
   "author": "agargaro",
   "license": "MIT",

--- a/src/patch/Object3D.ts
+++ b/src/patch/Object3D.ts
@@ -69,7 +69,7 @@ export interface Object3DExtPrototype {
   /** Indicates if the object is currently being clicked. */
   get clicking(): boolean;
   /** Indicates if the object is currently being dragged. */
-  get dragging(): boolean;
+  get isDragging(): boolean;
   /** Retrieves the combined enabled state considering parent objects. */
   get enabledState(): boolean;
   /** Retrieves the combined visibility state considering parent objects. */
@@ -257,7 +257,7 @@ Object.defineProperty(Object3D.prototype, "clicking", {
   }
 });
 
-Object.defineProperty(Object3D.prototype, "dragging", {
+Object.defineProperty(Object3D.prototype, "isDragging", {
   get: function (this: Object3D) {
     return this.__dragging;
   }


### PR DESCRIPTION
The `dragging` property was renamed `isDragging` because of a conflict with `transformControls`